### PR TITLE
Fix x402 websockets

### DIFF
--- a/src/wrapper/Client.ts
+++ b/src/wrapper/Client.ts
@@ -5,10 +5,10 @@ import { Supplier } from "../core/index.js";
 import { NoOpAuthProvider } from "../core/auth/NoOpAuthProvider.js";
 import { AgentMailEnvironment } from "../environments.js";
 import { AgentMailClient as FernAgentMailClient } from "../Client.js";
-import { type GetPaymentHeaders, WebsocketsClient } from "./WebsocketsClient.js";
+import { type GetPaymentCredentials, WebsocketsClient } from "./WebsocketsClient.js";
 
-import { getPaymentHeaders as getX402PaymentHeaders } from "./x402.js";
-import { getPaymentHeaders as getMppPaymentHeaders } from "./mpp.js";
+import { getPaymentCredentials as getX402Credentials } from "./x402.js";
+import { getPaymentCredentials as getMppCredentials } from "./mpp.js";
 
 type SharedOptions = Omit<FernAgentMailClient.Options, "apiKey">;
 
@@ -24,10 +24,10 @@ export declare namespace AgentMailClient {
 
 export class AgentMailClient extends FernAgentMailClient {
     protected declare _websockets: WebsocketsClient | undefined;
-    private readonly _getPaymentHeaders: GetPaymentHeaders | undefined;
+    private readonly _getPaymentCredentials: GetPaymentCredentials | undefined;
 
     public override get websockets(): WebsocketsClient {
-        return (this._websockets ??= new WebsocketsClient(this._options, this._getPaymentHeaders));
+        return (this._websockets ??= new WebsocketsClient(this._options, this._getPaymentCredentials));
     }
 
     constructor(options: AgentMailClient.Options = {}) {
@@ -53,7 +53,7 @@ export class AgentMailClient extends FernAgentMailClient {
 
             super(fernOptions);
 
-            this._getPaymentHeaders = (wsUrl) => getX402PaymentHeaders(wsUrl, x402);
+            this._getPaymentCredentials = (wsUrl) => getX402Credentials(wsUrl, x402);
         } else if (options.mpp) {
             const { mpp, ...rest } = options;
 
@@ -69,7 +69,7 @@ export class AgentMailClient extends FernAgentMailClient {
 
             super(fernOptions);
 
-            this._getPaymentHeaders = (wsUrl) => getMppPaymentHeaders(wsUrl, mpp);
+            this._getPaymentCredentials = (wsUrl) => getMppCredentials(wsUrl, mpp);
         } else {
             let fernOptions: FernAgentMailClient.Options = options;
 
@@ -86,7 +86,7 @@ export class AgentMailClient extends FernAgentMailClient {
 
             super(fernOptions);
 
-            this._getPaymentHeaders = undefined;
+            this._getPaymentCredentials = undefined;
         }
     }
 }

--- a/src/wrapper/WebsocketsClient.ts
+++ b/src/wrapper/WebsocketsClient.ts
@@ -3,28 +3,28 @@ import type { WebsocketsSocket } from "../api/resources/websockets/client/Socket
 import * as core from "../core/index.js";
 import * as environments from "../environments.js";
 
-export type GetPaymentHeaders = (wsUrl: string) => Promise<Record<string, string>>;
+export type GetPaymentCredentials = (wsUrl: string) => Promise<Record<string, string>>;
 
 export class WebsocketsClient extends FernWebsocketsClient {
-    private readonly _getPaymentHeaders: GetPaymentHeaders | undefined;
+    private readonly _getPaymentCredentials: GetPaymentCredentials | undefined;
 
-    constructor(options: FernWebsocketsClient.Options, getPaymentHeaders?: GetPaymentHeaders) {
+    constructor(options: FernWebsocketsClient.Options, getPaymentCredentials?: GetPaymentCredentials) {
         super(options);
-        this._getPaymentHeaders = getPaymentHeaders;
+        this._getPaymentCredentials = getPaymentCredentials;
     }
 
     public override async connect(args: FernWebsocketsClient.ConnectArgs = {}): Promise<WebsocketsSocket> {
-        if (this._getPaymentHeaders) {
+        if (this._getPaymentCredentials) {
             const wsUrl = core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     ((await core.Supplier.get(this._options.environment)) ?? environments.AgentMailEnvironment.Prod)
                         .websockets,
                 "/v0",
             );
-            const paymentHeaders = await this._getPaymentHeaders(wsUrl);
+            const credentials = await this._getPaymentCredentials(wsUrl);
             return super.connect({
                 ...args,
-                headers: { ...paymentHeaders, ...args.headers },
+                queryParams: { ...credentials, ...args.queryParams },
             });
         }
 

--- a/src/wrapper/mpp.ts
+++ b/src/wrapper/mpp.ts
@@ -1,7 +1,7 @@
 import type { Mppx } from "mppx/client";
 import { probe402 } from "./probe402.js";
 
-export async function getPaymentHeaders(wsUrl: string, mpp: Mppx.Mppx): Promise<Record<string, string>> {
+export async function getPaymentCredentials(wsUrl: string, mpp: Mppx.Mppx): Promise<Record<string, string>> {
     const response = await probe402(wsUrl);
 
     const credential = await mpp.createCredential(response);

--- a/src/wrapper/x402.ts
+++ b/src/wrapper/x402.ts
@@ -1,7 +1,7 @@
 import type { x402Client } from "@x402/fetch";
 import { probe402 } from "./probe402.js";
 
-export async function getPaymentHeaders(wsUrl: string, client: x402Client): Promise<Record<string, string>> {
+export async function getPaymentCredentials(wsUrl: string, client: x402Client): Promise<Record<string, string>> {
     const { x402HTTPClient } = await import("@x402/fetch");
     const httpClient = new x402HTTPClient(client);
 

--- a/tests/unit/wrapper/WebsocketsClient.test.ts
+++ b/tests/unit/wrapper/WebsocketsClient.test.ts
@@ -58,10 +58,10 @@ describe("WebsocketsClient wrapper", () => {
 
     describe("with x402", () => {
         const mockX402Client = {};
-        const mockPaymentHeaders = { "X-PAYMENT": "signed-payload" };
+        const mockCredentials = { "PAYMENT-SIGNATURE": "signed-payload" };
 
-        it("should call getPaymentHeaders and merge into connect args", async () => {
-            const spy = vi.spyOn(x402Helpers, "getPaymentHeaders").mockResolvedValue(mockPaymentHeaders);
+        it("should call getPaymentCredentials and pass as queryParams", async () => {
+            const spy = vi.spyOn(x402Helpers, "getPaymentCredentials").mockResolvedValue(mockCredentials);
 
             const client = new AgentMailClient({ x402: mockX402Client });
             await client.websockets.connect();
@@ -69,22 +69,24 @@ describe("WebsocketsClient wrapper", () => {
             expect(spy).toHaveBeenCalled();
             expect(connectSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    headers: expect.objectContaining(mockPaymentHeaders),
+                    queryParams: expect.objectContaining(mockCredentials),
                 }),
             );
 
             spy.mockRestore();
         });
 
-        it("should let user headers override payment headers", async () => {
-            const spy = vi.spyOn(x402Helpers, "getPaymentHeaders").mockResolvedValue({ "X-PAYMENT": "from-x402" });
+        it("should let user queryParams override payment credentials", async () => {
+            const spy = vi
+                .spyOn(x402Helpers, "getPaymentCredentials")
+                .mockResolvedValue({ "PAYMENT-SIGNATURE": "from-x402" });
 
             const client = new AgentMailClient({ x402: mockX402Client });
-            await client.websockets.connect({ headers: { "X-PAYMENT": "user-override" } });
+            await client.websockets.connect({ queryParams: { "PAYMENT-SIGNATURE": "user-override" } });
 
             expect(connectSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    headers: expect.objectContaining({ "X-PAYMENT": "user-override" }),
+                    queryParams: expect.objectContaining({ "PAYMENT-SIGNATURE": "user-override" }),
                 }),
             );
 
@@ -98,10 +100,10 @@ describe("WebsocketsClient wrapper", () => {
             transport: { setCredential: vi.fn() },
             createCredential: vi.fn(),
         };
-        const mockPaymentHeaders = { Authorization: "Payment signed-credential" };
+        const mockCredentials = { Authorization: "Payment signed-credential" };
 
-        it("should call getPaymentHeaders and merge into connect args", async () => {
-            const spy = vi.spyOn(mppHelpers, "getPaymentHeaders").mockResolvedValue(mockPaymentHeaders);
+        it("should call getPaymentCredentials and pass as queryParams", async () => {
+            const spy = vi.spyOn(mppHelpers, "getPaymentCredentials").mockResolvedValue(mockCredentials);
 
             const client = new AgentMailClient({ mpp: mockMppClient });
             await client.websockets.connect();
@@ -109,22 +111,22 @@ describe("WebsocketsClient wrapper", () => {
             expect(spy).toHaveBeenCalled();
             expect(connectSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    headers: expect.objectContaining(mockPaymentHeaders),
+                    queryParams: expect.objectContaining(mockCredentials),
                 }),
             );
 
             spy.mockRestore();
         });
 
-        it("should let user headers override payment headers", async () => {
-            const spy = vi.spyOn(mppHelpers, "getPaymentHeaders").mockResolvedValue({ Authorization: "from-mpp" });
+        it("should let user queryParams override payment credentials", async () => {
+            const spy = vi.spyOn(mppHelpers, "getPaymentCredentials").mockResolvedValue({ Authorization: "from-mpp" });
 
             const client = new AgentMailClient({ mpp: mockMppClient });
-            await client.websockets.connect({ headers: { Authorization: "user-override" } });
+            await client.websockets.connect({ queryParams: { Authorization: "user-override" } });
 
             expect(connectSpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    headers: expect.objectContaining({ Authorization: "user-override" }),
+                    queryParams: expect.objectContaining({ Authorization: "user-override" }),
                 }),
             );
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix websockets auth for x402/mpp by sending payment credentials as query params instead of headers. This resolves connection failures during the WS handshake.

- **Bug Fixes**
  - Renamed GetPaymentHeaders to GetPaymentCredentials and updated x402/mpp helpers.
  - WebsocketsClient now merges credentials into connect queryParams (not headers).
  - AgentMailClient passes getPaymentCredentials for x402/mpp; tests updated to confirm user queryParams override credentials.

<sup>Written for commit 5e3dbd31e50f158ab97d93f3c29c8b41ccdd2222. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

