### PR TITLE
WS wait for open on connect

### DIFF
--- a/src/wrapper/WebsocketsClient.ts
+++ b/src/wrapper/WebsocketsClient.ts
@@ -14,6 +14,8 @@ export class WebsocketsClient extends FernWebsocketsClient {
     }
 
     public override async connect(args: FernWebsocketsClient.ConnectArgs = {}): Promise<WebsocketsSocket> {
+        let connectArgs = args;
+
         if (this._getPaymentCredentials) {
             const wsUrl = core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
@@ -22,17 +24,17 @@ export class WebsocketsClient extends FernWebsocketsClient {
                 "/v0",
             );
             const credentials = await this._getPaymentCredentials(wsUrl);
-            return super.connect({
+            connectArgs = {
                 ...args,
                 queryParams: { ...credentials, ...args.queryParams },
-            });
-        }
-
-        if (!args.apiKey) {
+            };
+        } else if (!args.apiKey) {
             const apiKey = (await core.Supplier.get(this._options.apiKey)) ?? process.env.AGENTMAIL_API_KEY;
-            return super.connect({ ...args, apiKey });
+            connectArgs = { ...args, apiKey };
         }
 
-        return super.connect(args);
+        const socket = await super.connect(connectArgs);
+        await socket.waitForOpen();
+        return socket;
     }
 }

--- a/tests/unit/wrapper/WebsocketsClient.test.ts
+++ b/tests/unit/wrapper/WebsocketsClient.test.ts
@@ -5,7 +5,9 @@ import * as x402Helpers from "../../../src/wrapper/x402";
 import * as mppHelpers from "../../../src/wrapper/mppx";
 
 function mockConnect() {
-    return vi.spyOn(FernWebsocketsClient.prototype, "connect").mockResolvedValue({} as WebsocketsSocket);
+    return vi
+        .spyOn(FernWebsocketsClient.prototype, "connect")
+        .mockResolvedValue({ waitForOpen: vi.fn().mockResolvedValue(undefined) } as unknown as WebsocketsSocket);
 }
 
 describe("WebsocketsClient wrapper", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure WebsocketsClient.connect waits for the socket to open before returning. This prevents race conditions when sending messages right after connect.

- **Bug Fixes**
  - Call socket.waitForOpen() after super.connect.
  - Build connectArgs once, merging payment credentials or apiKey.
  - Update unit test to mock waitForOpen.

<sup>Written for commit 674d67a023b53f483aa3524b882ef86bc543322a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

