### PR TITLE
Fix MPP fetch

### DIFF
--- a/src/wrapper/mppx.ts
+++ b/src/wrapper/mppx.ts
@@ -2,6 +2,7 @@ import { probe402, wsToHttp } from "./util.js";
 
 export interface MppxClient {
     fetch: typeof globalThis.fetch;
+    rawFetch: typeof globalThis.fetch;
     transport: {
         setCredential(request: Request, credential: string): RequestInit;
     };
@@ -9,7 +10,7 @@ export interface MppxClient {
 }
 
 export async function getPaymentCredentials(wsUrl: string, mppx: MppxClient): Promise<Record<string, string>> {
-    const response = await probe402(wsUrl);
+    const response = await probe402(wsUrl, mppx.rawFetch);
 
     const credential = await mppx.createCredential(response);
     const signed = mppx.transport.setCredential(new Request(wsToHttp(wsUrl)), credential);

--- a/src/wrapper/util.ts
+++ b/src/wrapper/util.ts
@@ -2,10 +2,10 @@ export function wsToHttp(wsUrl: string): string {
     return wsUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
 }
 
-export async function probe402(wsUrl: string): Promise<Response> {
+export async function probe402(wsUrl: string, fetchFn: typeof fetch = fetch): Promise<Response> {
     const httpUrl = wsToHttp(wsUrl);
 
-    const response = await fetch(httpUrl);
+    const response = await fetchFn(httpUrl);
     if (response.status !== 402) {
         throw new Error(`Expected 402 from ${httpUrl} but got ${response.status}`);
     }

--- a/tests/unit/wrapper/Client.test.ts
+++ b/tests/unit/wrapper/Client.test.ts
@@ -106,6 +106,7 @@ describe("AgentMailClient environment selection", () => {
         const mockMppFetch = vi.fn().mockResolvedValue(new Response());
         const mockMppClient = {
             fetch: mockMppFetch,
+            rawFetch: vi.fn().mockResolvedValue(new Response()),
             transport: { setCredential: vi.fn() },
             createCredential: vi.fn(),
         };

--- a/tests/unit/wrapper/WebsocketsClient.test.ts
+++ b/tests/unit/wrapper/WebsocketsClient.test.ts
@@ -99,6 +99,7 @@ describe("WebsocketsClient wrapper", () => {
     describe("with mppx", () => {
         const mockMppClient = {
             fetch: vi.fn(),
+            rawFetch: vi.fn(),
             transport: { setCredential: vi.fn() },
             createCredential: vi.fn(),
         };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes MPP/x402 fetch by using the client's raw fetch for the initial 402 probe, avoiding signed requests and enabling correct credential creation. Aligns with ENG-300 (SDKs x402/MPP).

- **Bug Fixes**
  - `probe402` now accepts an optional `fetchFn` and uses it.
  - `getPaymentCredentials` passes `mppx.rawFetch` to `probe402`.
  - Updated unit tests to mock `rawFetch`.

<sup>Written for commit 3e77ef99dc657d01f402aa32e32417cca8d05230. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

