### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run check
+      - run: pnpm run build
+      - run: pnpm run test:unit


### PR DESCRIPTION
## Summary
Adds CI workflow.
## Testing
CI passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions CI workflow to run checks, build, and unit tests on pushes and PRs to `main`. Standardizes Node 20 with `pnpm` and caches dependencies for faster runs.

- **New Features**
  - Triggers on `push` and `pull_request` to `main`.
  - Sets up Node 20, `pnpm` 10.33.0, and enables `pnpm` cache.
  - Runs `pnpm install --frozen-lockfile`, `pnpm run check`, `pnpm run build`, and `pnpm run test:unit`.

<sup>Written for commit f755acc723c0d90e785771e089d862b26656866f. Summary will update on new commits. <a href="https://cubic.dev/pr/agentmail-to/agentmail-node/pull/17?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

