### PR TITLE
ci: add security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,27 @@ jobs:
       - name: Compile
         run: pnpm build
 
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run security audit
+        run: pnpm audit --audit-level=high
+
   test:
+    needs: [ compile ]
     runs-on: ubuntu-latest
 
     steps:
@@ -46,7 +66,7 @@ jobs:
         run: pnpm test
 
   publish:
-    needs: [ compile, test ]
+    needs: [ compile, test, security ]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
Adds security scanning to CI.
## Testing
CI passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `security` job to CI that runs `pnpm audit --audit-level=high` and blocks releases on high-severity findings. This helps catch vulnerable dependencies before publishing.

- **New Features**
  - Added `security` job using `actions/checkout@v6`, `actions/setup-node@v6`, and `pnpm/action-setup@v4`; installs with `--frozen-lockfile` and runs `pnpm audit --audit-level=high`.
  - Updated dependencies between jobs: `test` now needs `compile`; `publish` now needs `compile`, `test`, and `security`.

<sup>Written for commit bc8f80b3f6c4d1f683862792435141e594225c0e. Summary will update on new commits. <a href="https://cubic.dev/pr/agentmail-to/agentmail-node/pull/19?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

